### PR TITLE
Fix docs typo for Upload File

### DIFF
--- a/docs/public/docs/quickstart.md
+++ b/docs/public/docs/quickstart.md
@@ -68,7 +68,7 @@ curl --request POST http://localhost:8080/api/buckets \
 ```bash
 curl --request POST http://localhost:8080/api/buckets/my_bucket/files \
   --header 'Content-Type: multipart/form-data' \
-  --form file={path_to_your_file} \
+  --form file=@{path_to_your_file} \
   --form strict=false
 ```
 


### PR DESCRIPTION
# Pull Request Template

## Description
While trying to upload a file into my bucket I faced a problem and I noticed that this little thing was missed in the documentation

## Changes Made
Just add a '@' before the path file

## Screenshots / Logs
Curl from the documentation:
```bash
curl --request POST http://localhost:8080/api/buckets/stefan_bucket/files \
  --header 'Content-Type: multipart/form-data' \
  --form file=./fiskalna1.jpeg \
  --form strict=false

{"data":null,"error":{"message":"Error retrieving the file"}}
```

Curl that was working for me:
```bash
curl --request POST http://localhost:8080/api/buckets/stefan_bucket/files \
  --header 'Content-Type: multipart/form-data' \
  --form file=@./fiskalna1.jpeg \
  --form strict=false

{"data":{"name":"fiskalna1.jpeg","bucket":"stefan_bucket","size":2839443,"extension":"jpeg","type":"image","createdAt":"2025-05-12T20:51:51.206797388Z","visibility":"public"},"error":null}
```

## Checklist
- [ ] Code follows the project's style guidelines.
- [x] Documentation has been updated (if applicable).
- [ ] Tests have been added or updated.
- [ ] All new and existing tests pass.

## Additional Notes
*Any additional context or information.*

---

**Thank you for your contribution!** 🚀

